### PR TITLE
[TASK] Fetch and merge exception codes in working directory

### DIFF
--- a/create/app/config.inc.php
+++ b/create/app/config.inc.php
@@ -6,5 +6,8 @@ return [
     ],
     'template' => [
         'lifetime' => 24 * 3600
+    ],
+    'codes' => [
+        'workingDir' => dirname(__FILE__) . '/packages/exception-pages/res/exceptions'
     ]
 ];

--- a/create/app/packages/exception-pages/bin/fetch-exception-code-files
+++ b/create/app/packages/exception-pages/bin/fetch-exception-code-files
@@ -3,7 +3,10 @@
 
 require dirname(dirname(dirname(dirname(__FILE__)))) . '/vendor/autoload.php';
 
+$config = include dirname(dirname(dirname(dirname(__FILE__)))) . '/config.php';
+
 $typo3ReleasePattern = !empty($argv[1]) ? $argv[1] : '';
 $force = !empty($argv[2]) ? (bool)$argv[2] : false;
 $exceptionCodes = new \Typo3\ExceptionPages\ExceptionCodes();
+$exceptionCodes->setWorkingDir($config['codes']['workingDir'] ?? $exceptionCodes->getWorkingDir());
 $exceptionCodes->fetchFiles($typo3ReleasePattern, $force);

--- a/create/app/packages/exception-pages/bin/merge-exception-code-files
+++ b/create/app/packages/exception-pages/bin/merge-exception-code-files
@@ -3,7 +3,10 @@
 
 require dirname(dirname(dirname(dirname(__FILE__)))) . '/vendor/autoload.php';
 
+$config = include dirname(dirname(dirname(dirname(__FILE__)))) . '/config.php';
+
 $typo3ReleasePattern = !empty($argv[1]) ? $argv[1] : '';
-$fileName = !empty($argv[2]) ? $argv[2] : '';
+$mergeFileName = !empty($argv[2]) ? $argv[2] : '';
 $exceptionCodes = new \Typo3\ExceptionPages\ExceptionCodes();
-$exceptionCodes->mergeFiles($typo3ReleasePattern, $fileName);
+$exceptionCodes->setWorkingDir($config['codes']['workingDir'] ?? $exceptionCodes->getWorkingDir());
+$exceptionCodes->mergeFiles($typo3ReleasePattern, $mergeFileName);


### PR DESCRIPTION
New fetched TYPO3 exception code files get saved in the working
directory which can be different from the current files directory.
If it is different, then code files of both - files and working -
directory get considered for the final merged exception codes file
and that file gets saved to and read from the working directory.

This feature helps defining an exception codes directory outside
of the app folder as that folder gets completely overwritten with each
app deployment.